### PR TITLE
Added 'hidegui' switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Supported values of `key` are: (if `value` is not mentioned then it does not mat
 * `resizable`: Whether the window can be resized.
 * `width`, `height`: Initial window width/height on program start. The values can be in hexadecimal (prefix `0x`), octal (prefix `0`) or decimal.
 * `exit_on_console_shutdown`: Exit the emulator when the console thread is shut down.
+* `hidegui`: Don't show debugger windows.
 
 Note that passing an argument at least twice will cause the program to panic.
 

--- a/emulator/src/Gui/Command.cpp
+++ b/emulator/src/Gui/Command.cpp
@@ -55,8 +55,14 @@ void gui_loop(){
     ImGui_ImplSDLRenderer2_RenderDrawData(ImGui::GetDrawData());
     SDL_RenderPresent(renderer);
 }
-int test_gui(bool* guiCreated){
+int test_gui(bool* guiCreated, bool guiHidden){
     //SDL_Delay(1000*5);
+    if (guiHidden) 
+    {
+        SDL_Log("Debugger GUI disabled with \"hidegui\" switch");
+        window_flags = (SDL_WindowFlags)(window_flags | SDL_WINDOW_HIDDEN);
+    }
+
     window = SDL_CreateWindow("CasioEmuX", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, 1280, 720, window_flags);
     renderer = SDL_CreateRenderer(window, -1, SDL_RENDERER_PRESENTVSYNC | SDL_RENDERER_ACCELERATED);
     if (renderer == nullptr)

--- a/emulator/src/Gui/ui.hpp
+++ b/emulator/src/Gui/ui.hpp
@@ -2,7 +2,7 @@
 #include "../Emulator.hpp"
 #include "../Chipset/MMU.hpp"
 #include "CodeViewer.hpp"
-int test_gui(bool* guiCreated);
+int test_gui(bool* guiCreated, bool guiHidden);
 void gui_cleanup();
 void gui_loop();
 extern char *n_ram_buffer;

--- a/emulator/src/casioemu.cpp
+++ b/emulator/src/casioemu.cpp
@@ -139,8 +139,9 @@ int main(int argc, char *argv[]) {
         });
 
         bool guiCreated = false;
+        bool guiHidden  = argv_map.find("hidegui") != argv_map.end();
         std::thread t1([&]() {
-            test_gui(&guiCreated);
+            test_gui(&guiCreated, guiHidden);
             while (1) {
                 SDL_Event event;
                 gui_loop();


### PR DESCRIPTION
It not disable but just hide window with memory and other debug info. If you want to use it just as calculator. Console window is still visible though.